### PR TITLE
Corrige aplicação de sombra

### DIFF
--- a/estilo/style.css
+++ b/estilo/style.css
@@ -66,7 +66,7 @@ header > p {
 nav {
     background-color:var(--cor5);
     padding: 10px;
-    box-shadow: 0px 7px 7px ( 0, 0, 0, 0.192);
+    box-shadow: 0px 7px 7px rgba(0, 0, 0, 0.192);
 }
 
 nav > a {


### PR DESCRIPTION
Sem a aplicação do prefixo `rgba` a propriedade está sendo descartada:
https://developer.mozilla.org/en-US/docs/Web/CSS/box-shadow